### PR TITLE
Fix for nullable additional columns

### DIFF
--- a/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle/Core/OracleDatabaseBatchSink.cs
+++ b/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle/Core/OracleDatabaseBatchSink.cs
@@ -97,6 +97,13 @@ namespace Serilog.Sinks.Oracle.Core
                     case StandardColumn.Id:
                         break;
                     default:
+					    
+						// if there are no properties for the additional column, pass a null value
+                        if (!events.Any(e => e.Properties.TryGetValue(ci.ColumnName, out _)))
+                        {
+                            break;
+                        }
+					
                         var untypedArray = events
                             .Select(x => x.Properties[ci.ColumnName])
                             .Select(x => new {Data = x, Type = x.GetType()})


### PR DESCRIPTION
If an additional column is added to the log table that's NULLABLE and the corresponding property isn't provided, Line 100 of OracleDatabaseBatchSink.cs throws an exception that the column name isn't in the property dictionary ("The given key '{keyName}' was not present in the dictionary.").