### PR TITLE
Adds .NET 6.0 support

### DIFF
--- a/Serilog.Sinks.Oracle.nuspec
+++ b/Serilog.Sinks.Oracle.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Serilog.Sinks.Oracle</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>Sink for Serilog, flushes logs on Oracle</title>
     <authors>Lucas Cé Bertin</authors>
     <owners>Lucas Cé Bertin</owners>
@@ -12,7 +12,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <description>A Serilog sink that writes events to Oracle</description>
     <summary>A Serilog sink that writes events to Oracle</summary>
-    <releaseNotes>Add multiple framework(.NET4.5.2,.NET4.6.1, and .NETStandard2.0) support</releaseNotes>
+    <releaseNotes>Add .NET 6.0 support</releaseNotes>
     <tags>Serilog Sinks Oracle</tags>
   </metadata>
 </package>

--- a/build.cake
+++ b/build.cake
@@ -118,6 +118,16 @@ Task("Publish")
 					ArgumentCustomization = args => args.Append("--no-restore"),
 				});
 
+			// .NET 6.0
+			DotNetCorePublish(
+				project.FullPath,
+				new DotNetCorePublishSettings()
+				{
+					Configuration = configuration,
+					Framework = "net6.0",
+					OutputDirectory = build.ToString() + "/lib/net6.0",
+					ArgumentCustomization = args => args.Append("--no-restore"),
+				});
 			}
     });
 
@@ -221,6 +231,28 @@ Task("Package-NuGet")
 												Id = "NETStandard.Library",
 												TargetFramework="netstandard2.0", 
 												Version="2.0.3"
+											},
+
+											// .NET 6.0
+											new NuSpecDependency {
+												Id = "Serilog", 
+												TargetFramework="net6.0", 
+												Version="2.10.0"
+											},
+											new NuSpecDependency {
+												Id = "Serilog.Sinks.PeriodicBatching",
+												TargetFramework="net6.0", 
+												Version="2.3.1"
+											},
+											new NuSpecDependency {
+												Id = "FakeItEasy", 
+												TargetFramework="net6.0",
+												Version="7.3.0"
+											},
+											new NuSpecDependency {
+												Id = "Oracle.ManagedDataAccess.Core", 
+												TargetFramework="net6.0",
+												Version="3.21.50"
 											},
 										},
                                      BasePath                = build,

--- a/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle.ConsoleTester/Serilog.Sinks.Oracle.ConsoleTester.csproj
+++ b/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle.ConsoleTester/Serilog.Sinks.Oracle.ConsoleTester.csproj
@@ -1,30 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net452;net461;netcoreapp2.1</TargetFrameworks>
-    <Platforms>AnyCPU</Platforms>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>net452;net461;netcoreapp2.1;net6.0</TargetFrameworks>
+		<Platforms>AnyCPU</Platforms>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.8.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.8.0" />
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.6" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\Serilog.Sinks.Oracle\Serilog.Sinks.Oracle.csproj" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'net461'">
+		<PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
+		<Reference Include="System.Configuration" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.6" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.50" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Serilog.Sinks.Oracle\Serilog.Sinks.Oracle.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle.UnitTests/Serilog.Sinks.Oracle.UnitTests.csproj
+++ b/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle.UnitTests/Serilog.Sinks.Oracle.UnitTests.csproj
@@ -1,54 +1,67 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
 
-    <TargetFrameworks>net452;net461;netcoreapp2.1</TargetFrameworks>
-    <Platforms>AnyCPU</Platforms>
-    
-  </PropertyGroup>
+		<TargetFrameworks>net452;net461;netcoreapp2.1;net6.0</TargetFrameworks>
+		<Platforms>AnyCPU</Platforms>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="FakeItEasy" Version="5.1.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	</PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="FakeItEasy" Version="5.1.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+		<PackageReference Include="FakeItEasy" Version="5.1.0" />
+		<PackageReference Include="FluentAssertions" Version="5.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+		<PackageReference Include="Serilog" Version="2.8.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="FakeItEasy" Version="5.1.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+		<PackageReference Include="FakeItEasy" Version="5.1.0" />
+		<PackageReference Include="FluentAssertions" Version="5.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+		<PackageReference Include="Serilog" Version="2.8.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Serilog.Sinks.Oracle\Serilog.Sinks.Oracle.csproj" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+		<PackageReference Include="FakeItEasy" Version="5.1.0" />
+		<PackageReference Include="FluentAssertions" Version="5.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+		<PackageReference Include="Serilog" Version="2.8.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="FakeItEasy" Version="7.3.0" />
+		<PackageReference Include="FluentAssertions" Version="6.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Serilog.Sinks.Oracle\Serilog.Sinks.Oracle.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle.csproj
+++ b/src/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle/Serilog.Sinks.Oracle.csproj
@@ -1,58 +1,65 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>A Serilog sink that writes events to Oracle</Description>
+	<PropertyGroup>
+		<Description>A Serilog sink that writes events to Oracle</Description>
 
-    <Authors>Lucas Cé Bertin</Authors>
-    <PackageId>Serilog.Sinks.Oracle</PackageId>
-    <PackageTags>serilog;sinks;oracle</PackageTags>
-    <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/lucascebertin/Serilog.Sinks.Oracle</PackageProjectUrl>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+		<Authors>Lucas Cé Bertin</Authors>
+		<PackageId>Serilog.Sinks.Oracle</PackageId>
+		<PackageTags>serilog;sinks;oracle</PackageTags>
+		<PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
+		<PackageProjectUrl>https://github.com/lucascebertin/Serilog.Sinks.Oracle</PackageProjectUrl>
+		<PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
 
-    <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
-    
-    <Version>1.1.0</Version>
-    <AssemblyName>Serilog.Sinks.Oracle</AssemblyName>
-    <RootNamespace>Serilog.Sinks.Oracle</RootNamespace>
-    <Platforms>AnyCPU</Platforms>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
-  </PropertyGroup>
+		<TargetFrameworks>net452;net461;netstandard2.0;net6.0</TargetFrameworks>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-  </PropertyGroup>
+		<Version>1.2.0</Version>
+		<AssemblyName>Serilog.Sinks.Oracle</AssemblyName>
+		<RootNamespace>Serilog.Sinks.Oracle</RootNamespace>
+		<Platforms>AnyCPU</Platforms>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+	</PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net452'">
-    <PackageReference Include="FakeItEasy" Version="5.1.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="FakeItEasy" Version="5.1.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
+	<ItemGroup Condition="$(TargetFramework) == 'net452'">
+		<PackageReference Include="FakeItEasy" Version="5.1.0" />
+		<PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
+		<PackageReference Include="Serilog" Version="2.8.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="FakeItEasy" Version="5.1.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.6" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+		<PackageReference Include="FakeItEasy" Version="5.1.0" />
+		<PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
+		<PackageReference Include="Serilog" Version="2.8.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="OracleBurstSink.cs" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="FakeItEasy" Version="5.1.0" />
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.6" />
+		<PackageReference Include="Serilog" Version="2.8.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Burst" Version="1.0.1" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="FakeItEasy" Version="7.3.0" />
+		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.50" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Remove="OracleBurstSink.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Serilog.Sinks.Burst" Version="1.0.1" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds .net6.0 target framework with updated dependencies.
Tests passing, integration tested in our project.

Why? We were getting annoying exceptions about binaryformatter. .NET 6.0 fixes this.